### PR TITLE
🔧[chore] D.R.Y. up revision counter

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -1,5 +1,11 @@
 # Lets try to keep a revision tracking via commit number.
-revision = 'c+117'
+from subprocess import Popen, PIPE
+
+# $ git rev-list <branch> --count # retrieves full commit count of HEAD (master)
+process = Popen(['git', 'rev-list', 'HEAD', '--count'], stdout=PIPE, stderr=PIPE)
+
+ # use .join for O(n) time complexity (concatenation would be O(n^2))
+revision = ''.join ([ 'c+', process.communicate () [0].strip () ])
 
 # Set this for parameters checking
 hypedSkus = ['BY9612', 'BY1605', 'BY9611']


### PR DESCRIPTION
Closes #8 (< autoclose issue when merged)

## Problem
Revision count aggregator is not very DRY (https://en.wikipedia.org/wiki/Don't_repeat_yourself).
Currently it's a human _(i.e. @SOLEMARTYR)_

## Solution
We should use a child process to bring in the commit count into the application
using the following git (porcelain) command.
Trust me this will either become a nightmare, or will bit rot until someone takes it out.

```bash
$ git rev-list <branch> --count # More DRY approach
```

Trust me... Been here before...

## References
:link: Git (porcelain) man page - https://git-scm.com/docs/git-rev-list